### PR TITLE
Add worker node ID

### DIFF
--- a/.idea/inspectionProfiles/ignore_unreachable.xml
+++ b/.idea/inspectionProfiles/ignore_unreachable.xml
@@ -1,0 +1,15 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="ignore_unreachable" />
+    <inspection_tool class="InconsistentLineSeparators" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyMandatoryEncodingInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyPep8Inspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="E501" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyUnreachableCodeInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,7 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <settings>
-    <option name="PROJECT_PROFILE" value="avoid_unreachable_code" />
-    <option name="USE_PROJECT_PROFILE" value="false" />
+    <option name="PROJECT_PROFILE" value="ignore_unreachable" />
     <version value="1.0" />
   </settings>
 </component>

--- a/README.ja.md
+++ b/README.ja.md
@@ -255,7 +255,7 @@ study_register_param = StudyRegisterParam(
         ),
     ),
 )
-client = TableNodeClient("xxx.xxx.xxx.xxx:8000", name="admin node")
+client = TableNodeClient("xxx.xxx.xxx.xxx", port=8000)
 client.register_study(study_register_param)
 ```
 curl の場合:
@@ -306,7 +306,8 @@ worker_config = WorkerConfig(
 )
 worker = Worker(
     trial_runner=Mandelbrot(),
-    ip="xxx.xxx.xxx.xxx:8000",
+    ip="xxx.xxx.xxx.xxx",
+    port=8000,
     config=worker_config,
 )
 worker.start()
@@ -321,7 +322,7 @@ worker.start()
 Python の場合:
 ```python
 from lite_dist2.worker_node.table_node_client import TableNodeClient
-client = TableNodeClient("xxx.xxx.xxx.xxx:8000", name="admin node")
+client = TableNodeClient("xxx.xxx.xxx.xxx", port=8000)
 study = client.study(name="mandelbrot")
 ```
 
@@ -449,6 +450,7 @@ curl 'xxx.xxx.xxx.xxx:8000/study?name=mandelbrot'
 | retaining_capacity | list[str]   | ✓  | そのワーカーノードが対応できるタスクの種類 (内部的な型は `set[str]`)。 |
 | max_size           | int         | ✓  | 予約するパラメータ空間の最大サイズ。                         |
 | worker_node_name   | str \| None |    | ワーカーノードの名前。                                |
+| worker_node_id     | str         |    | ワーカーノードのID。                                |
 
 ### TrialRegisterParam
 | 名前    | 型                         | 必須 | 説明                    |
@@ -557,6 +559,7 @@ curl 'xxx.xxx.xxx.xxx:8000/study?name=mandelbrot'
 | result_type       | Literal["scalar", "vector"]                                                                                          | ✓  | この `Trial` の戻り値が１変数か、多変数かを表す値。必ず親の `Study.result_type` と一致する。                        |
 | result_value_type | Literal["bool", "int", "float"]                                                                                      | ✓  | この `Trial` の戻り値の型。必ず親の `Study.result_value_type` と一致する。                              |
 | worker_node_name  | str \| None                                                                                                          |    | 実行するワーカーノードの名前。                                                                      |
+| worker_node_id    | str                                                                                                                  |    | 実行するワーカーノードのID。                                                                      |
 | results           | list[[Mapping](#mapping)] \| None                                                                                    |    | この `Trial` の結果。                                                                      |
 
 ### Mapping

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ study_register_param = StudyRegisterParam(
         ),
     ),
 )
-client = TableNodeClient("xxx.xxx.xxx.xxx:8000", name="admin node")
+client = TableNodeClient(ip="xxx.xxx.xxx.xxx", port=8000)
 client.register_study(study_register_param)
 ```
 In curl:
@@ -310,7 +310,8 @@ worker_config = WorkerConfig(
 )
 worker = Worker(
     trial_runner=Mandelbrot(),
-    ip="xxx.xxx.xxx.xxx:8000",
+    ip="xxx.xxx.xxx.xxx",
+    port=8000,
     config=worker_config,
 )
 worker.start()
@@ -325,7 +326,7 @@ As before, this process can be done in Python via a client class or using API to
 In Python:
 ```python
 from lite_dist2.worker_node.table_node_client import TableNodeClient
-client = TableNodeClient("xxx.xxx.xxx.xxx:8000", name="admin node")
+client = TableNodeClient(ip="xxx.xxx.xxx.xxx", port=8000)
 study = client.study(name="mandelbrot")
 ```
 
@@ -452,7 +453,8 @@ If you look at `result`, you will see that it contains both `param` and `result`
 |--------------------|-------------|----------|-------------------------------------------------------------------------------------------|
 | retaining_capacity | list[str]   | ✓        | Types of tasks that can be performed by that worker node (internally of type `set[str]`). |
 | max_size           | int         | ✓        | Maximum size of parameter space to be reserved.                                           |
-| worker_node_name   | str \| None |          | name of the worker node.                                                                  |
+| worker_node_name   | str \| None |          | Name of the worker node.                                                                  |
+| worker_node_id     | str         |          | ID of the worker node.                                                                    |
 
 ### TrialRegisterParam
 | name  | type                      | required | description                            |
@@ -561,6 +563,7 @@ If you look at `result`, you will see that it contains both `param` and `result`
 | result_type       | Literal["scalar", "vector"]                                                                                          | ✓        | A value indicating whether the return value of this `Trial` is scalar or vector. It always matches the parent `Study.result_type`. |
 | result_value_type | Literal["bool", "int", "float"]                                                                                      | ✓        | The return type of this `Trial`. It always matches the parent `Study.result_value_type`.                                           |
 | worker_node_name  | str \| None                                                                                                          |          | Name of the worker node to run.                                                                                                    |
+| worker_node_id    | str                                                                                                                  |          | ID of the worker node to run.                                                                                                      |
 | results           | list[[Mapping](#mapping)] \| None                                                                                    |          | The results of this `Trial`.                                                                                                       |
 
 ### Mapping

--- a/example/generate_hash_preimage.py
+++ b/example/generate_hash_preimage.py
@@ -67,7 +67,7 @@ def register_study(table_ip: str, table_port: int) -> None:
             ),
         ),
     )
-    client = TableNodeClient(table_ip, table_port, name="admin node")
+    client = TableNodeClient(table_ip, table_port)
     client.register_study(study_register_param)
 
 

--- a/example/generate_mandelbrot_set.py
+++ b/example/generate_mandelbrot_set.py
@@ -62,7 +62,7 @@ def register_study(table_ip: str, table_port: int) -> None:
             ),
         ),
     )
-    client = TableNodeClient(table_ip, table_port, name="admin node")
+    client = TableNodeClient(table_ip, table_port)
     client.register_study(study_register_param)
 
 

--- a/src/lite_dist2/curriculum_models/study.py
+++ b/src/lite_dist2/curriculum_models/study.py
@@ -58,7 +58,12 @@ class Study:
     def is_done(self) -> bool:
         return self.study_strategy.is_done(self.trial_table, self.parameter_space)
 
-    def suggest_next_trial(self, num: int | None, worker_node_name: str | None) -> Trial | None:
+    def suggest_next_trial(
+        self,
+        num: int | None,
+        worker_node_name: str | None,
+        worker_node_id: str,
+    ) -> Trial | None:
         with self._table_lock:
             self.status = StudyStatus.running
 
@@ -75,6 +80,7 @@ class Study:
                 result_type=self.result_type,
                 result_value_type=self.result_value_type,
                 worker_node_name=worker_node_name,
+                worker_node_id=worker_node_id,
             )
             self.trial_table.register(trial)
         if self.trial_table.is_not_defined_aps():
@@ -83,7 +89,7 @@ class Study:
 
     def receipt_trial(self, trial: Trial) -> None:
         with self._table_lock:
-            self.trial_table.receipt_trial_result(trial.trial_id, trial.result)
+            self.trial_table.receipt_trial_result(trial.trial_id, trial.result, trial.worker_node_id)
             self.trial_table.simplify_aps()
 
     def check_timeout_trial(self, now: datetime, timeout_seconds: int) -> list[str]:

--- a/src/lite_dist2/curriculum_models/trial.py
+++ b/src/lite_dist2/curriculum_models/trial.py
@@ -35,6 +35,7 @@ class TrialModel(BaseModel):
     result_type: Literal["scalar", "vector"]
     result_value_type: Literal["bool", "int", "float"]
     worker_node_name: str | None
+    worker_node_id: str
     results: list[Mapping] | None = None
 
 
@@ -49,6 +50,7 @@ class Trial:
         result_type: Literal["scalar", "vector"],
         result_value_type: Literal["bool", "int", "float"],
         worker_node_name: str | None,
+        worker_node_id: str,
         results: list[Mapping] | None = None,
     ) -> None:
         self.study_id = study_id
@@ -59,6 +61,7 @@ class Trial:
         self.result_type = result_type
         self.result_value_type = result_value_type
         self.worker_node_name = worker_node_name
+        self.worker_node_id = worker_node_id
         self.result = results
 
     def convert_mappings_from(self, raw_mappings: list[tuple[RawParamType, RawResultType]]) -> list[Mapping]:
@@ -112,6 +115,7 @@ class Trial:
             result_type=self.result_type,
             result_value_type=self.result_value_type,
             worker_node_name=self.worker_node_name,
+            worker_node_id=self.worker_node_id,
             results=self.result,
         )
 
@@ -133,5 +137,6 @@ class Trial:
             result_type=model.result_type,
             result_value_type=model.result_value_type,
             worker_node_name=model.worker_node_name,
+            worker_node_id=model.worker_node_id,
             results=model.results,
         )

--- a/src/lite_dist2/curriculum_models/trial_table.py
+++ b/src/lite_dist2/curriculum_models/trial_table.py
@@ -47,7 +47,7 @@ class TrialTable:
     def register(self, trial: Trial) -> None:
         self.trials.append(trial)
 
-    def receipt_trial_result(self, receipted_trial_id: str, result: list[Mapping] | None) -> None:
+    def receipt_trial_result(self, receipted_trial_id: str, result: list[Mapping] | None, worker_node_id: str) -> None:
         if result is None:
             # Do nothing
             return
@@ -55,6 +55,10 @@ class TrialTable:
         for trial in reversed(self.trials):
             if trial.trial_id != receipted_trial_id:
                 continue
+            if trial.worker_node_id != worker_node_id:
+                p = "worker_node_id"
+                t = "This trial is reserved by other worker"
+                raise LD2ParameterError(p, t)
             if trial.trial_status == TrialStatus.done:
                 p = "receipted_trial_id"
                 t = f"Cannot override result of done trial(id={receipted_trial_id})"

--- a/src/lite_dist2/table_node_api/table_param.py
+++ b/src/lite_dist2/table_node_api/table_param.py
@@ -30,6 +30,10 @@ class TrialReserveParam(BaseParam):
         default=None,
         description="Name of the worker node. ",
     )
+    worker_node_id: str = Field(
+        ...,
+        description="ID of the worker node",
+    )
 
 
 class TrialRegisterParam(BaseModel):

--- a/src/lite_dist2/worker_node/worker.py
+++ b/src/lite_dist2/worker_node/worker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
+import uuid
 from typing import TYPE_CHECKING, Annotated
 
 from lite_dist2.expections import LD2TableNodeServerError
@@ -31,9 +32,10 @@ class Worker:
         ] = None,
     ) -> None:
         self.trial_runner = trial_runner
-        self.client = TableNodeClient(ip, port, config.name)
+        self.client = TableNodeClient(ip, port)
         self.pool = pool
         self.config = config
+        self.id = str(uuid.uuid1())
 
     def start(self, stop_at_no_trial: bool = False, *args: object, **kwargs: object) -> None:
         if not self.client.ping():
@@ -52,6 +54,8 @@ class Worker:
 
     def _step(self, *args: object, **kwargs: object) -> bool:
         trial = self.client.reserve_trial(
+            self.id,
+            self.config.name,
             self.config.max_size,
             self.config.retaining_capacity,
             self.config.table_node_request_timeout_seconds,

--- a/tests/curriculum_models/test_curriculum.py
+++ b/tests/curriculum_models/test_curriculum.py
@@ -155,6 +155,7 @@ def sample_curriculum_fixture() -> Curriculum:
                             result_type="scalar",
                             result_value_type="float",
                             worker_node_name="w01",
+                            worker_node_id="w01",
                             results=[
                                 Mapping(
                                     params=(
@@ -189,6 +190,7 @@ def sample_curriculum_fixture() -> Curriculum:
                             result_type="scalar",
                             result_value_type="float",
                             worker_node_name="w01",
+                            worker_node_id="w01",
                         ),
                     ],
                     aggregated_parameter_space={

--- a/tests/curriculum_models/test_study.py
+++ b/tests/curriculum_models/test_study.py
@@ -92,6 +92,7 @@ from tests.const import DT
                             result_type="scalar",
                             result_value_type="float",
                             worker_node_name="w01",
+                            worker_node_id="w01",
                             results=[
                                 Mapping(
                                     params=(
@@ -149,6 +150,7 @@ from tests.const import DT
                             result_type="scalar",
                             result_value_type="float",
                             worker_node_name="w01",
+                            worker_node_id="w01",
                         ),
                     ],
                     aggregated_parameter_space={
@@ -235,7 +237,7 @@ def test_study_suggest_receipt_single_thread() -> None:
 
     def contract_and_submit() -> None:
         # trial 取得
-        trial = study.suggest_next_trial(num=5, worker_node_name="w01")
+        trial = study.suggest_next_trial(num=5, worker_node_name="w01", worker_node_id="w01")
         if trial is None:
             return
 
@@ -299,7 +301,7 @@ def test_study_suggest_receipt_multi_threads_synchronous() -> None:
 
     def contract_and_submit() -> None:
         # trial 取得
-        trial = study.suggest_next_trial(num=5, worker_node_name="w01")
+        trial = study.suggest_next_trial(num=5, worker_node_name="w01", worker_node_id="w01")
 
         # 結果書き込み
         raw_mappings = []

--- a/tests/curriculum_models/test_trial.py
+++ b/tests/curriculum_models/test_trial.py
@@ -27,6 +27,7 @@ _dummy_space = ParameterJaggedSpace(
                 result_type="scalar",
                 result_value_type="int",
                 worker_node_name="w01",
+                worker_node_id="w01",
                 results=[
                     Mapping(
                         params=(ScalarValue(type="scalar", value_type="int", value="0x0"),),
@@ -52,6 +53,7 @@ _dummy_space = ParameterJaggedSpace(
                 result_type="scalar",
                 result_value_type="int",
                 worker_node_name="w01",
+                worker_node_id="w01",
                 results=None,
             ),
             ScalarValue(type="scalar", value_type="int", value="0x66"),
@@ -68,6 +70,7 @@ _dummy_space = ParameterJaggedSpace(
                 result_type="scalar",
                 result_value_type="int",
                 worker_node_name="w01",
+                worker_node_id="w01",
                 results=[],
             ),
             ScalarValue(type="scalar", value_type="int", value="0x66"),
@@ -84,6 +87,7 @@ _dummy_space = ParameterJaggedSpace(
                 result_type="scalar",
                 result_value_type="int",
                 worker_node_name="w01",
+                worker_node_id="w01",
                 results=[
                     Mapping(
                         params=(ScalarValue(type="scalar", value_type="int", value="0x0"),),
@@ -112,6 +116,7 @@ _dummy_space = ParameterJaggedSpace(
                 result_type="vector",
                 result_value_type="int",
                 worker_node_name="w01",
+                worker_node_id="w01",
                 results=[
                     Mapping(
                         params=(ScalarValue(type="scalar", value_type="int", value="0x0"),),
@@ -163,6 +168,7 @@ def test_trial_find_target_value(trial: Trial, target: ResultType, expected: Map
             result_type="scalar",
             result_value_type="bool",
             worker_node_name="w01",
+            worker_node_id="w01",
         ),
         TrialModel(
             study_id="my_study_id1",
@@ -187,6 +193,7 @@ def test_trial_find_target_value(trial: Trial, target: ResultType, expected: Map
             result_type="scalar",
             result_value_type="float",
             worker_node_name="w01",
+            worker_node_id="w01",
             results=[
                 Mapping(
                     params=(
@@ -231,6 +238,7 @@ def test_trial_find_target_value(trial: Trial, target: ResultType, expected: Map
             result_type="scalar",
             result_value_type="int",
             worker_node_name="w01",
+            worker_node_id="w01",
         ),
         TrialModel(
             study_id="my_study_id3",
@@ -257,6 +265,7 @@ def test_trial_find_target_value(trial: Trial, target: ResultType, expected: Map
             result_type="scalar",
             result_value_type="int",
             worker_node_name="w01",
+            worker_node_id="w01",
             results=[
                 Mapping(
                     params=(

--- a/tests/curriculum_models/test_trial_table.py
+++ b/tests/curriculum_models/test_trial_table.py
@@ -311,6 +311,7 @@ _DUMMY_PARAMETER_SPACE = ParameterAlignedSpace(
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -412,6 +413,7 @@ _DUMMY_PARAMETER_SPACE = ParameterAlignedSpace(
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -478,6 +480,7 @@ _DUMMY_PARAMETER_SPACE = ParameterAlignedSpace(
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                     ),
                 ],
                 aggregated_parameter_space={
@@ -572,6 +575,7 @@ _DUMMY_PARAMETER_SPACE = ParameterAlignedSpace(
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -676,6 +680,7 @@ _DUMMY_PARAMETER_SPACE = ParameterAlignedSpace(
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -745,6 +750,7 @@ _DUMMY_PARAMETER_SPACE = ParameterAlignedSpace(
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                     ),
                 ],
                 aggregated_parameter_space={
@@ -1098,6 +1104,7 @@ def test_trial_table_count_grid(
                     result_type="scalar",
                     result_value_type="float",
                     worker_node_name="w01",
+                    worker_node_id="w01",
                 ),
             ],
             aggregated_parameter_space=None,
@@ -1126,6 +1133,7 @@ def test_trial_table_count_grid(
                     result_type="scalar",
                     result_value_type="float",
                     worker_node_name="w01",
+                    worker_node_id="w01",
                     results=[
                         Mapping(
                             params=(
@@ -1157,7 +1165,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
 
 
 @pytest.mark.parametrize(
-    ("trial_table", "trial_id", "result", "expected"),
+    ("trial_table", "trial_id", "worker_node_id", "result", "expected"),
     [
         pytest.param(
             TrialTable(
@@ -1191,6 +1199,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -1245,6 +1254,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=None,
                     ),
                     Trial(
@@ -1276,6 +1286,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -1352,6 +1363,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                 },
             ),
             "t02",
+            "w01",
             None,
             TrialTable(
                 trials=[
@@ -1384,6 +1396,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -1438,6 +1451,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=None,
                     ),
                     Trial(
@@ -1469,6 +1483,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -1578,6 +1593,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -1632,6 +1648,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=None,
                     ),
                     Trial(
@@ -1663,6 +1680,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -1739,6 +1757,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                 },
             ),
             "t02",
+            "w01",
             [
                 Mapping(
                     params=(
@@ -1794,6 +1813,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -1848,6 +1868,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -1902,6 +1923,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -2019,6 +2041,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -2060,6 +2083,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=None,
                     ),
                     Trial(
@@ -2078,6 +2102,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -2154,6 +2179,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                 },
             ),
             "t02",
+            "w01",
             [
                 Mapping(
                     params=(
@@ -2196,6 +2222,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -2237,6 +2264,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -2278,6 +2306,7 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -2381,10 +2410,11 @@ def test_trial_table_to_model_from_model(model: TrialTableModel) -> None:
 def test_trial_table_receipt_trial_result(
     trial_table: TrialTable,
     trial_id: str,
+    worker_node_id: str,
     result: list[Mapping] | None,
     expected: TrialTable,
 ) -> None:
-    trial_table.receipt_trial_result(trial_id, result)
+    trial_table.receipt_trial_result(trial_id, result, worker_node_id)
     actual_model = trial_table.to_model()
     expected_model = expected.to_model()
     assert actual_model.trials == expected_model.trials
@@ -2410,6 +2440,7 @@ def test_trial_table_receipt_trial_result_raise_override_done_trial() -> None:
                 result_type="scalar",
                 result_value_type="int",
                 worker_node_name="w01",
+                worker_node_id="w01",
                 results=[
                     Mapping(
                         params=(
@@ -2447,7 +2478,7 @@ def test_trial_table_receipt_trial_result_raise_override_done_trial() -> None:
     ]
 
     with pytest.raises(LD2ParameterError, match=r"Cannot\soverride\sresult\sof\sdone\strial"):
-        trial_table.receipt_trial_result("t01", result)
+        trial_table.receipt_trial_result("t01", result, "w01")
 
 
 # noinspection SpellCheckingInspection
@@ -2472,10 +2503,54 @@ def test_trial_table_receipt_trial_result_raise_not_found_trial() -> None:
     ]
 
     with pytest.raises(LD2ParameterError, match=r"Not\sfound\strial\sthat\sid"):
-        trial_table.receipt_trial_result("t01", result)
+        trial_table.receipt_trial_result("t01", result, "w01")
 
 
-def test_trial_table_heck_timeout_trial() -> None:
+# noinspection SpellCheckingInspection
+def test_trial_table_receipt_trial_result_raise_unmatch_worker_id() -> None:
+    trial_table = TrialTable(
+        trials=[
+            Trial(
+                study_id="s01",
+                trial_id="t01",
+                timestamp=DT,
+                trial_status=TrialStatus.running,
+                parameter_space=ParameterAlignedSpace(
+                    axes=[
+                        ParameterRangeInt(type="int", size=1, ambient_index=0, ambient_size=100, start=0, name="x"),
+                        ParameterRangeInt(type="int", size=1, ambient_index=0, ambient_size=100, start=0, name="y"),
+                    ],
+                    check_lower_filling=True,
+                ),
+                result_type="scalar",
+                result_value_type="int",
+                worker_node_name="w01",
+                worker_node_id="w01",
+                results=None,
+            ),
+        ],
+        aggregated_parameter_space={
+            -1: [],
+            0: [],
+            1: [],
+        },
+    )
+
+    result = [
+        Mapping(
+            params=(
+                ScalarValue(type="scalar", value_type="int", value="0x0", name="x"),
+                ScalarValue(type="scalar", value_type="int", value="0x0", name="y"),
+            ),
+            result=ScalarValue(type="scalar", value_type="int", value="0x0", name="p2"),
+        ),
+    ]
+
+    with pytest.raises(LD2ParameterError, match=r"This\strial\sis\sreserved\sby\sother\sworker"):
+        trial_table.receipt_trial_result("t01", result, "w02")
+
+
+def test_trial_table_check_timeout_trial() -> None:
     common_param = {
         "study_id": "s01",
         "parameter_space": _DUMMY_PARAMETER_SPACE,
@@ -2483,6 +2558,7 @@ def test_trial_table_heck_timeout_trial() -> None:
         "result_value_type": "int",
         "results": [],
         "worker_node_name": "w01",
+        "worker_node_id": "w01",
     }
 
     now = DT

--- a/tests/study_strategy/test_all_calculation_study_strategy.py
+++ b/tests/study_strategy/test_all_calculation_study_strategy.py
@@ -23,6 +23,7 @@ _TRIAL_ARGS = {
     "result_type": "scalar",
     "result_value_type": "int",
     "worker_node_name": "w01",
+    "worker_node_id": "w01",
 }
 
 

--- a/tests/study_strategy/test_find_exact_study_strategy.py
+++ b/tests/study_strategy/test_find_exact_study_strategy.py
@@ -24,6 +24,7 @@ _TRIAL_ARGS = {
     "result_type": "scalar",
     "result_value_type": "int",
     "worker_node_name": "w01",
+    "worker_node_id": "w01",
 }
 
 

--- a/tests/suggest_strategies/test_sequential_suggest_strategy.py
+++ b/tests/suggest_strategies/test_sequential_suggest_strategy.py
@@ -480,6 +480,7 @@ def test_sequential_suggest_strategy_nullable_min_raise_both_none() -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(ScalarValue(type="scalar", value_type="int", value="0x0", name="x"),),
@@ -594,6 +595,7 @@ def test_sequential_suggest_strategy_nullable_min_raise_both_none() -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(ScalarValue(type="scalar", value_type="int", value="0x0", name="x"),),
@@ -667,6 +669,7 @@ def test_sequential_suggest_strategy_nullable_min_raise_both_none() -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -760,6 +763,7 @@ def test_sequential_suggest_strategy_nullable_min_raise_both_none() -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -800,6 +804,7 @@ def test_sequential_suggest_strategy_nullable_min_raise_both_none() -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -927,6 +932,7 @@ def test_sequential_suggest_strategy_nullable_min_raise_both_none() -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -980,6 +986,7 @@ def test_sequential_suggest_strategy_nullable_min_raise_both_none() -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -1107,6 +1114,7 @@ def test_sequential_suggest_strategy_nullable_min_raise_both_none() -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(
@@ -1213,6 +1221,7 @@ def test_sequential_suggest_strategy_nullable_min_raise_both_none() -> None:
                         result_type="scalar",
                         result_value_type="int",
                         worker_node_name="w01",
+                        worker_node_id="w01",
                         results=[
                             Mapping(
                                 params=(


### PR DESCRIPTION
Added worker node ID to Trial so that when Trial registers, it will look at this ID and only accept results from the same node as the reserved node.