### PR TITLE
immutable type

### DIFF
--- a/src/lite_dist2/curriculum_models/trial.py
+++ b/src/lite_dist2/curriculum_models/trial.py
@@ -16,6 +16,8 @@ from lite_dist2.value_models.point import ResultType, ScalarValue, VectorValue
 from lite_dist2.value_models.space_model import SpacePortableModelType
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from lite_dist2.type_definitions import RawParamType, RawResultType
     from lite_dist2.value_models.base_space import FlattenSegment
     from lite_dist2.value_models.space_type import ParameterSpaceType
@@ -86,7 +88,7 @@ class Trial:
         self.result = results
         self.registered_timestamp = registered_timestamp
 
-    def convert_mappings_from(self, raw_mappings: list[tuple[RawParamType, RawResultType]]) -> list[Mapping]:
+    def convert_mappings_from(self, raw_mappings: Sequence[tuple[RawParamType, RawResultType]]) -> list[Mapping]:
         mappings = []
         for raw_param, raw_res in raw_mappings:
             param = self.parameter_space.value_tuple_to_param_type(raw_param)
@@ -94,8 +96,8 @@ class Trial:
             mappings.append(Mapping(params=param, result=result))
         return mappings
 
-    def set_result(self, mappings: list[Mapping]) -> None:
-        self.result = mappings
+    def set_result(self, mappings: Sequence[Mapping]) -> None:
+        self.result = list(mappings)
 
     def set_registered_timestamp(self) -> None:
         self.registered_timestamp = publish_timestamp()

--- a/src/lite_dist2/value_models/aligned_space.py
+++ b/src/lite_dist2/value_models/aligned_space.py
@@ -11,7 +11,7 @@ from lite_dist2.value_models.point import ParamType, ScalarValue
 from lite_dist2.value_models.space_model import ParameterAlignedSpacePortableModel
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Sequence
 
     from lite_dist2.type_definitions import PrimitiveValueType
 
@@ -164,7 +164,7 @@ class ParameterAlignedSpace(BaseSpace):
                 return i
         return -1
 
-    def slice(self, start_and_sizes: list[tuple[int, int]]) -> ParameterAlignedSpace:
+    def slice(self, start_and_sizes: Sequence[tuple[int, int]]) -> ParameterAlignedSpace:
         if len(start_and_sizes) != self.dim:
             msg = "start_and_sizes"
             raise LD2ParameterError(msg, "different size to axes")

--- a/src/lite_dist2/value_models/const_param.py
+++ b/src/lite_dist2/value_models/const_param.py
@@ -9,6 +9,8 @@ from lite_dist2.common import float2hex, int2hex, numerize
 from lite_dist2.expections import LD2UndefinedError
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from lite_dist2.type_definitions import ConstParamType
 
 
@@ -48,5 +50,5 @@ class ConstParam(BaseModel):
         return {const.key: const.unpack() for const in self.consts}
 
     @staticmethod
-    def from_dict(d: dict[str, ConstParamType]) -> ConstParam:
+    def from_dict(d: Mapping[str, ConstParamType]) -> ConstParam:
         return ConstParam(consts=list(starmap(ConstParamElement.from_kv, d.items())))

--- a/src/lite_dist2/value_models/parameter_aligned_space_helper.py
+++ b/src/lite_dist2/value_models/parameter_aligned_space_helper.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from lite_dist2.value_models.base_space import FlattenSegment
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Iterable
+    from collections.abc import Generator, Iterable, Sequence
 
     from lite_dist2.value_models.aligned_space import ParameterAlignedSpace
 
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 type Mergeable = ParameterAlignedSpace | FlattenSegment
 
 
-def simplify[T: Mergeable](mergeables: list[T], *args: object) -> list[T]:
+def simplify[T: Mergeable](mergeables: Sequence[T], *args: object) -> list[T]:
     new_aps = []
     mergeables_duplicated_group: dict[int, set[int]] = {}
     sub_space_num = len(mergeables)
@@ -55,7 +55,7 @@ def simplify[T: Mergeable](mergeables: list[T], *args: object) -> list[T]:
     return sorted(new_aps, key=lambda spc: spc.get_start_index(*args))
 
 
-def remap_space(aps: list[ParameterAlignedSpace], dim: int) -> dict[int, list[ParameterAlignedSpace]]:
+def remap_space(aps: Sequence[ParameterAlignedSpace], dim: int) -> dict[int, list[ParameterAlignedSpace]]:
     remapped = {i: [] for i in range(-1, dim)}
 
     for space in aps:

--- a/src/lite_dist2/worker_node/trial_runner.py
+++ b/src/lite_dist2/worker_node/trial_runner.py
@@ -13,7 +13,7 @@ from lite_dist2.expections import LD2TypeError
 from lite_dist2.type_definitions import ConstParamType, PrimitiveValueType
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Mapping
 
     from lite_dist2.config import WorkerConfig
     from lite_dist2.curriculum_models.trial import Trial
@@ -62,7 +62,7 @@ class BaseTrialRunner(abc.ABC):
         return trial
 
     @staticmethod
-    def get_typed[T](key: str, value_type: type[T], d: dict[str, object]) -> T:
+    def get_typed[T](key: str, value_type: type[T], d: Mapping[str, object]) -> T:
         v = d.get(key)
         if isinstance(v, value_type):
             return v


### PR DESCRIPTION
Since mutable data can cause problems, use `Sequence` and `Mapping` instead of `list` and `dict`.